### PR TITLE
アニメーションGIF終了中に300秒経過するとエラーになる問題の修正

### DIFF
--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -189,8 +189,14 @@ type AnimeCapture = {
 };
 
 const ANIME_CAPTURE_ID_PREFIX = 'anime-capture:';
+const KEEP_ALIVE_PREFIX = 'keep-alive:';
 
 port.listenPort().addListener(port => {
+    // KeepAliveのための接続の場合は何もせず保持
+    if (port.name.startsWith(KEEP_ALIVE_PREFIX)) {
+        return;
+    }
+    // アニメキャプチャ以外の接続であれば切断
     if (!port.name.startsWith(ANIME_CAPTURE_ID_PREFIX)) {
         port.disconnect();
         return;


### PR DESCRIPTION
* ServiceWorker起動後300秒経過するとServiceWorkerが終了するため、変換中はPortを定期的に開くことで終了を阻止する