### PR TITLE
スクリーンショットが多い場合はまとめて保存で作成するzipファイルを分割する

### DIFF
--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -71,6 +71,9 @@
   "prefs_general_notify_duration": {
     "message": "通知の表示時間"
   },
+  "prefs_general_files_per_archive": {
+    "message": "ZIPファイル毎のスクリーンショット数"
+  },
   "prefs_screenshot_hotkey": {
     "message": "スクリーンショット撮影のキー設定"
   },
@@ -285,7 +288,7 @@
     "message": "キャンセル"
   },
   "album_download_preparing_label": {
-    "message": "ZIPファイル準備中..."
+    "message": "ZIPファイル作成中..."
   },
   "album_tweet_screenshot_button": {
     "message": "Tweet"

--- a/src/js/libs/prefs.ts
+++ b/src/js/libs/prefs.ts
@@ -53,6 +53,7 @@ export type Preferences = {
         notify: boolean,
         notifyPosition: ToastPosition,
         notifyDuration: number,
+        filesPerArchive: number,
     },
     screenshot: {
         hotkey: hotkeys.KeyConfig,
@@ -88,6 +89,7 @@ export const DefaultPreferences: Preferences = {
         notify: true,
         notifyPosition: ToastPositions.LeftBottom,
         notifyDuration: 1000,
+        filesPerArchive: 1000,
     },
     screenshot: {
         hotkey: hotkeys.getKeyConfig('S', { shift: true }),
@@ -131,6 +133,7 @@ function completePreferences(prefs: Preferences): Preferences {
             notify: completeBool(prefs?.general?.notify, DefaultPreferences.general.notify),
             notifyPosition: completeToastPosition(prefs?.general?.notifyPosition, DefaultPreferences.general.notifyPosition),
             notifyDuration: completeMinMax(prefs?.general?.notifyDuration, DefaultPreferences.general.notifyDuration, 100, 60000),
+            filesPerArchive: completeMinMax(prefs?.general?.filesPerArchive, DefaultPreferences.general.filesPerArchive, 100, 10000),
         },
         screenshot: {
             hotkey: completeKeyConfig(prefs?.screenshot?.hotkey, DefaultPreferences.screenshot.hotkey),

--- a/src/js/options/features/preference/GeneralPreferences.tsx
+++ b/src/js/options/features/preference/GeneralPreferences.tsx
@@ -82,6 +82,17 @@ const GeneralPreferences: React.FC = () => {
                         </LabeledControl>
                     </ControlGroup>
                 </ControlGroup>
+                <ControlGroup>
+                    <LabeledControl messageId="prefs_general_files_per_archive">
+                        <NumberInputControl<Preferences>
+                            name="general.filesPerArchive"
+                            w="10em"
+                            min={100}
+                            max={10000}
+                            step={100}
+                            precision={0} />
+                    </LabeledControl>
+                </ControlGroup>
             </Box>
         </PreferenceBlock>
     );


### PR DESCRIPTION
ファイル数が多いとzipファイル作成でメモリエラーになることがある問題への対応
* 一度に全てのスクリーンショットを取得せずに逐次取得するように変更
* zipファイルを分割してこまめに保存することでメモリに溜めないように変更