### PR TITLE
implemented screenshot save to clipboard

### DIFF
--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -98,6 +98,9 @@
   "prefs_screenshot_format_png": {
     "message": "PNG"
   },
+  "prefs_screenshot_enabled_save_to_clipboard": {
+    "message": "クリップボードに保存"
+  },
   "prefs_album_enable_virtual_scroll": {
     "message": "仮想スクロールの有効化"
   },

--- a/src/js/contents/capture.ts
+++ b/src/js/contents/capture.ts
@@ -113,6 +113,19 @@ function captureComplete(capture: Promise<ImageDataUrl>, prefs: prefs.Preference
             if (prefs.general.notify) {
                 showScreenshotToast(image, prefs);
             }
+            if (prefs.screenshot.fileType == "image/png" && prefs.screenshot.enabledSaveToClipboard) {
+                saveToClipboard(image)
+            }
         })
         .catch(() => null);
+}
+
+function saveToClipboard(image:ImageDataUrl)
+{
+    fetch(image)
+        .then(res => res.blob())
+        .then(blob => {
+            navigator.clipboard.write([new ClipboardItem({[blob.type]: blob})]);
+        });
+    
 }

--- a/src/js/libs/prefs.ts
+++ b/src/js/libs/prefs.ts
@@ -61,6 +61,7 @@ export type Preferences = {
         continuousInterval: number,
         fileType: FileType,
         quality: number,
+        enabledSaveToClipboard: boolean
     },
     album: {
         enabledVirtualScroll: boolean,
@@ -100,6 +101,7 @@ export const DefaultPreferences: Preferences = {
         continuousInterval: 500,
         fileType: 'image/jpeg',
         quality: 94,
+        enabledSaveToClipboard: false
     },
     animation: {
         enabled: true,
@@ -147,6 +149,7 @@ function completePreferences(prefs: Preferences): Preferences {
             continuousInterval: completeMinMax(prefs?.screenshot?.continuousInterval, DefaultPreferences.screenshot.continuousInterval, 1, 10000),
             fileType: completeFileType(prefs?.screenshot?.fileType, DefaultPreferences.screenshot.fileType),
             quality: completeMinMax(prefs?.screenshot?.quality, DefaultPreferences.screenshot.quality, 0, 100),
+            enabledSaveToClipboard: completeBool(prefs?.screenshot?.enabledSaveToClipboard, DefaultPreferences.screenshot.enabledSaveToClipboard),
         },
         album: {
             enabledVirtualScroll: completeBool(prefs?.album?.enabledVirtualScroll, DefaultPreferences.album.enabledVirtualScroll),

--- a/src/js/options/features/preference/ScreenshotPreferences.tsx
+++ b/src/js/options/features/preference/ScreenshotPreferences.tsx
@@ -70,6 +70,11 @@ const ScreenshotPreferences: React.FC = () => {
                     </RadioGroupControl>
                 </LabeledControl>
             </ControlGroup>
+            <ControlGroup isEnabledHover conditionKey="screenshot.fileType" conditionValue="image/png">
+                <LabeledControl messageId="prefs_screenshot_enabled_save_to_clipboard">
+                    <SwitchControl<Preferences> name="screenshot.enabledSaveToClipboard" />
+                </LabeledControl>
+            </ControlGroup>
         </PreferenceBlock>
     );
 };


### PR DESCRIPTION
This PR opens the option to save screenshot directly to the clipboard, available when PNG is selected.